### PR TITLE
Integrate legacy Grasshopper components into Components and Kernel

### DIFF
--- a/src/AssemblyChain.Grasshopper/Components/Base/AssemblyChainComponentBase.cs
+++ b/src/AssemblyChain.Grasshopper/Components/Base/AssemblyChainComponentBase.cs
@@ -3,12 +3,14 @@ using Grasshopper.Kernel;
 using IGhComponentBase = Grasshopper.Kernel.GH_Component;
 using IGhDataAccessInternal = Grasshopper.Kernel.IGH_DataAccess;
 #else
-using AssemblyChain.GH.Stubs;
-using IGhComponentBase = AssemblyChain.GH.Stubs.GhComponentBase;
-using IGhDataAccessInternal = AssemblyChain.GH.Components.IGhDataAccess;
+using AssemblyChain.Gh.Kernel.Legacy;
+using IGhComponentBase = AssemblyChain.Gh.Kernel.Legacy.GhComponentBase;
+using IGhDataAccessInternal = AssemblyChain.Gh.Kernel.Legacy.IGhDataAccess;
 #endif
 
-namespace AssemblyChain.GH.Components;
+using AssemblyChain.Gh.Kernel.Legacy;
+
+namespace AssemblyChain.Gh.Components.Legacy;
 
 public abstract class AssemblyChainComponentBase : IGhComponentBase
 {

--- a/src/AssemblyChain.Grasshopper/Components/Legacy/BuildNdbgComponent.cs
+++ b/src/AssemblyChain.Grasshopper/Components/Legacy/BuildNdbgComponent.cs
@@ -1,12 +1,9 @@
 using AssemblyChain.Constraints;
-using AssemblyChain.GH.Data;
+using AssemblyChain.Gh.Kernel.Legacy;
 using AssemblyChain.Geometry.ContactDetection;
-#if !GRASSHOPPER
-using AssemblyChain.GH.Stubs;
-#endif
 using AssemblyChain.Graphs;
 
-namespace AssemblyChain.GH.Components;
+namespace AssemblyChain.Gh.Components.Legacy;
 
 /// <summary>
 /// Builds the non-directional blocking graph from a set of contacts.

--- a/src/AssemblyChain.Grasshopper/Components/Legacy/ConstraintComponents.cs
+++ b/src/AssemblyChain.Grasshopper/Components/Legacy/ConstraintComponents.cs
@@ -1,12 +1,9 @@
 using AssemblyChain.Constraints;
 using AssemblyChain.Core.Spatial;
-using AssemblyChain.GH.Data;
-#if !GRASSHOPPER
-using AssemblyChain.GH.Stubs;
-#endif
+using AssemblyChain.Gh.Kernel.Legacy;
 using AssemblyChain.Geometry.ContactDetection;
 
-namespace AssemblyChain.GH.Components;
+namespace AssemblyChain.Gh.Components.Legacy;
 
 public sealed class ContactDetectorComponent : AssemblyChainComponentBase
 {

--- a/src/AssemblyChain.Grasshopper/Components/Legacy/DataIoComponents.cs
+++ b/src/AssemblyChain.Grasshopper/Components/Legacy/DataIoComponents.cs
@@ -1,13 +1,10 @@
 using System.Collections.Generic;
 using AssemblyChain.Core.DomainModel;
 using AssemblyChain.Core.Spatial;
-using AssemblyChain.GH.Data;
-#if !GRASSHOPPER
-using AssemblyChain.GH.Stubs;
-#endif
+using AssemblyChain.Gh.Kernel.Legacy;
 using AssemblyChain.IO;
 
-namespace AssemblyChain.GH.Components;
+namespace AssemblyChain.Gh.Components.Legacy;
 
 public sealed class ImportAssemblyComponent : AssemblyChainComponentBase
 {

--- a/src/AssemblyChain.Grasshopper/Components/Legacy/GraphComponents.cs
+++ b/src/AssemblyChain.Grasshopper/Components/Legacy/GraphComponents.cs
@@ -1,10 +1,7 @@
-using AssemblyChain.GH.Data;
-#if !GRASSHOPPER
-using AssemblyChain.GH.Stubs;
-#endif
+using AssemblyChain.Gh.Kernel.Legacy;
 using AssemblyChain.Graphs;
 
-namespace AssemblyChain.GH.Components;
+namespace AssemblyChain.Gh.Components.Legacy;
 
 public sealed class BuildAdjacencyComponent : AssemblyChainComponentBase
 {

--- a/src/AssemblyChain.Grasshopper/Components/Legacy/PlanningComponents.cs
+++ b/src/AssemblyChain.Grasshopper/Components/Legacy/PlanningComponents.cs
@@ -1,13 +1,10 @@
 using System.Collections.Generic;
 using AssemblyChain.Analysis;
 using AssemblyChain.Core.DomainModel;
-using AssemblyChain.GH.Data;
-#if !GRASSHOPPER
-using AssemblyChain.GH.Stubs;
-#endif
+using AssemblyChain.Gh.Kernel.Legacy;
 using AssemblyChain.Planning;
 
-namespace AssemblyChain.GH.Components;
+namespace AssemblyChain.Gh.Components.Legacy;
 
 public sealed class TreeSearchPlanningComponent : AssemblyChainComponentBase
 {

--- a/src/AssemblyChain.Grasshopper/Components/Legacy/RoboticsComponents.cs
+++ b/src/AssemblyChain.Grasshopper/Components/Legacy/RoboticsComponents.cs
@@ -1,10 +1,7 @@
-using AssemblyChain.GH.Data;
-#if !GRASSHOPPER
-using AssemblyChain.GH.Stubs;
-#endif
+using AssemblyChain.Gh.Kernel.Legacy;
 using AssemblyChain.Robotics;
 
-namespace AssemblyChain.GH.Components;
+namespace AssemblyChain.Gh.Components.Legacy;
 
 public sealed class UrScriptExportComponent : AssemblyChainComponentBase
 {

--- a/src/AssemblyChain.Grasshopper/Components/Legacy/SimulationComponents.cs
+++ b/src/AssemblyChain.Grasshopper/Components/Legacy/SimulationComponents.cs
@@ -1,13 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using AssemblyChain.Core.DomainModel;
-using AssemblyChain.GH.Data;
-#if !GRASSHOPPER
-using AssemblyChain.GH.Stubs;
-#endif
+using AssemblyChain.Gh.Kernel.Legacy;
 using AssemblyChain.Planning;
 
-namespace AssemblyChain.GH.Components;
+namespace AssemblyChain.Gh.Components.Legacy;
 
 public sealed class AnimatePlanComponent : AssemblyChainComponentBase
 {

--- a/src/AssemblyChain.Grasshopper/Components/Legacy/ValidationComponents.cs
+++ b/src/AssemblyChain.Grasshopper/Components/Legacy/ValidationComponents.cs
@@ -1,13 +1,10 @@
 using System.Collections.Generic;
 using AssemblyChain.Analysis;
 using AssemblyChain.Core.DomainModel;
-using AssemblyChain.GH.Data;
-#if !GRASSHOPPER
-using AssemblyChain.GH.Stubs;
-#endif
+using AssemblyChain.Gh.Kernel.Legacy;
 using AssemblyChain.Planning;
 
-namespace AssemblyChain.GH.Components;
+namespace AssemblyChain.Gh.Components.Legacy;
 
 public sealed class StabilityCheckComponent : AssemblyChainComponentBase
 {

--- a/src/AssemblyChain.Grasshopper/Kernel/Legacy/GhDataTypes.cs
+++ b/src/AssemblyChain.Grasshopper/Kernel/Legacy/GhDataTypes.cs
@@ -6,7 +6,7 @@ using AssemblyChain.Geometry.ContactDetection;
 using AssemblyChain.Graphs;
 using AssemblyChain.Planning;
 
-namespace AssemblyChain.GH.Data;
+namespace AssemblyChain.Gh.Kernel.Legacy;
 
 public sealed class GhAssembly
 {

--- a/src/AssemblyChain.Grasshopper/Kernel/Legacy/GrasshopperStubs.cs
+++ b/src/AssemblyChain.Grasshopper/Kernel/Legacy/GrasshopperStubs.cs
@@ -1,5 +1,5 @@
 #if !GRASSHOPPER
-namespace AssemblyChain.GH.Stubs;
+namespace AssemblyChain.Gh.Kernel.Legacy;
 
 /// <summary>
 /// Minimal stand-ins for Grasshopper base types so the project can build without the Rhino SDK.
@@ -28,7 +28,7 @@ public abstract class GhComponentBase
 /// <summary>
 /// Minimal data access helper that mirrors Grasshopper's IGH_DataAccess semantics for tests.
 /// </summary>
-public sealed class GhDataAccess : Components.IGhDataAccess
+public sealed class GhDataAccess : IGhDataAccess
 {
     private readonly System.Collections.Generic.Dictionary<int, object?> _inputs = new();
     private readonly System.Collections.Generic.Dictionary<int, object?> _outputs = new();

--- a/src/AssemblyChain.Grasshopper/Kernel/Legacy/IGhDataAccess.cs
+++ b/src/AssemblyChain.Grasshopper/Kernel/Legacy/IGhDataAccess.cs
@@ -1,4 +1,4 @@
-namespace AssemblyChain.GH.Components;
+namespace AssemblyChain.Gh.Kernel.Legacy;
 
 public interface IGhDataAccess
 {

--- a/tests/AssemblyChain.Core.Tests/GhIntegration/GhPipelineTests.cs
+++ b/tests/AssemblyChain.Core.Tests/GhIntegration/GhPipelineTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
-using AssemblyChain.GH.Components;
-using AssemblyChain.GH.Data;
-using AssemblyChain.GH.Stubs;
+using AssemblyChain.Gh.Components.Legacy;
+using AssemblyChain.Gh.Kernel.Legacy;
 using AssemblyChain.IO;
 using FluentAssertions;
 using Xunit;


### PR DESCRIPTION
## Summary
- move the legacy Grasshopper component base class, component files, and helper data wrappers into the Components and Kernel folders
- update namespaces/usings so the legacy components share the new AssemblyChain.Gh.* hierarchy and rely on the relocated kernel abstractions
- adjust the Grasshopper integration test to reference the new namespaces

## Testing
- dotnet test tests/AssemblyChain.Core.Tests/AssemblyChain.Core.Tests.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d33d59e88323b89240b8170b5822