### PR TITLE
Add geometry abstractions project skeleton

### DIFF
--- a/AssemblyChain-Core.sln
+++ b/AssemblyChain-Core.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyChain.Core", "src\A
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyChain.Grasshopper", "src\AssemblyChain.Grasshopper\AssemblyChain.Gh.csproj", "{D8899378-7DD1-4A8A-89A6-9A321C79E7A7}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyChain.Geometry.Abstractions", "src\AssemblyChain.Geometry.Abstractions\AssemblyChain.Geometry.Abstractions.csproj", "{B308A8D2-ED06-446F-99EB-F00CC428B87E}"
+EndProject
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyChain.Geometry", "src\AssemblyChain.Geometry\AssemblyChain.Geometry.csproj", "{F0B6F4C0-619F-4955-A16F-363E5A8E984D}"
 EndProject
@@ -75,6 +77,10 @@ Global
                 {B5E2D0F2-5B6F-4B18-8F93-3A40989B3909}.Debug|Any CPU.Build.0 = Debug|Any CPU
                 {B5E2D0F2-5B6F-4B18-8F93-3A40989B3909}.Release|Any CPU.ActiveCfg = Release|Any CPU
                 {B5E2D0F2-5B6F-4B18-8F93-3A40989B3909}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B308A8D2-ED06-446F-99EB-F00CC428B87E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B308A8D2-ED06-446F-99EB-F00CC428B87E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B308A8D2-ED06-446F-99EB-F00CC428B87E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B308A8D2-ED06-446F-99EB-F00CC428B87E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AssemblyChain.Geometry.Abstractions/AssemblyChain.Geometry.Abstractions.csproj
+++ b/src/AssemblyChain.Geometry.Abstractions/AssemblyChain.Geometry.Abstractions.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AssemblyName>AssemblyChain.Geometry.Abstractions</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <DocumentationFile>$(BaseIntermediateOutputPath)$(AssemblyName).xml</DocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IAABB.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IAABB.cs
@@ -1,0 +1,25 @@
+using AssemblyChain.Geometry.Abstractions.Primitives;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Describes an axis-aligned bounding box.
+/// </summary>
+public interface IAABB
+{
+    /// <summary>
+    /// Gets the minimum corner of the bounding box.
+    /// </summary>
+    Point3 Min { get; }
+
+    /// <summary>
+    /// Gets the maximum corner of the bounding box.
+    /// </summary>
+    Point3 Max { get; }
+
+    /// <summary>
+    /// Expands the bounding box by the specified tolerance.
+    /// </summary>
+    /// <param name="tolerance">The tolerance profile used for expansion.</param>
+    IAABB Expand(IToleranceProfile tolerance);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IBroadPhase.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IBroadPhase.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Defines the broad phase contact detection behaviour.
+/// </summary>
+public interface IBroadPhase
+{
+    IEnumerable<(int A, int B)> FindPairs(IMeshLite meshA, IMeshLite meshB);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IBvh.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IBvh.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Represents a bounding volume hierarchy abstraction used during collision detection.
+/// </summary>
+public interface IBvh
+{
+    IAABB Bounds { get; }
+
+    IEnumerable<IBvh> Children { get; }
+
+    bool IsLeaf { get; }
+
+    IReadOnlyList<int> Primitives { get; }
+
+    void Traverse(Action<IBvh> visitor);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IContact.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IContact.cs
@@ -1,0 +1,21 @@
+using AssemblyChain.Geometry.Abstractions.Primitives;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Represents a detected contact between two mesh elements.
+/// </summary>
+public interface IContact
+{
+    int ContactId { get; }
+
+    int SourceA { get; }
+
+    int SourceB { get; }
+
+    Point3 Position { get; }
+
+    IVector3 Normal { get; }
+
+    double PenetrationDepth { get; }
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IContactClassifier.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IContactClassifier.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Provides classification for contacts, grouping them into semantic categories.
+/// </summary>
+public interface IContactClassifier
+{
+    IReadOnlyDictionary<string, IReadOnlyCollection<IContact>> Classify(IEnumerable<IContact> contacts);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IContactDetector.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IContactDetector.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// High level service abstraction that detects contacts between two meshes.
+/// </summary>
+public interface IContactDetector
+{
+    IEnumerable<IContact> DetectContacts(IMeshLite meshA, IMeshLite meshB, IToleranceProfile tolerance);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IContactMerge.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IContactMerge.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Describes a service that merges duplicate or overlapping contacts.
+/// </summary>
+public interface IContactMerge
+{
+    IEnumerable<IContact> Merge(IEnumerable<IContact> contacts, IToleranceProfile tolerance);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IMatrix4.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IMatrix4.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Represents a 4x4 matrix abstraction used for transforms.
+/// </summary>
+public interface IMatrix4
+{
+    double this[int row, int column] { get; }
+
+    IEnumerable<double> GetRow(int rowIndex);
+
+    IEnumerable<double> GetColumn(int columnIndex);
+
+    double Determinant { get; }
+
+    IMatrix4 Multiply(IMatrix4 other);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IMeshLite.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IMeshLite.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using AssemblyChain.Geometry.Abstractions.Primitives;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Represents a lightweight mesh abstraction suitable for analysis pipelines.
+/// </summary>
+public interface IMeshLite
+{
+    IReadOnlyList<Point3> Vertices { get; }
+
+    IReadOnlyList<(int A, int B, int C)> Faces { get; }
+
+    IAABB Bounds { get; }
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/INarrowPhase.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/INarrowPhase.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Defines the narrow phase collision detection behaviour.
+/// </summary>
+public interface INarrowPhase
+{
+    IEnumerable<IContact> DetectContacts(IMeshLite meshA, IMeshLite meshB, IEnumerable<(int A, int B)> candidatePairs);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IPrimitive.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IPrimitive.cs
@@ -1,0 +1,14 @@
+using AssemblyChain.Geometry.Abstractions.Primitives;
+
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Marker interface for geometry primitives that can provide bounding volume information.
+/// </summary>
+public interface IPrimitive
+{
+    /// <summary>
+    /// Gets the axis-aligned bounding box that encloses the primitive.
+    /// </summary>
+    IAABB GetBounds();
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IToleranceProfile.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IToleranceProfile.cs
@@ -1,0 +1,11 @@
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Describes tolerances used throughout geometry processing pipelines.
+/// </summary>
+public interface IToleranceProfile
+{
+    double Linear { get; }
+
+    double Angular { get; }
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Interfaces/IVector3.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Interfaces/IVector3.cs
@@ -1,0 +1,21 @@
+namespace AssemblyChain.Geometry.Abstractions.Interfaces;
+
+/// <summary>
+/// Represents a 3D vector abstraction.
+/// </summary>
+public interface IVector3
+{
+    double X { get; }
+
+    double Y { get; }
+
+    double Z { get; }
+
+    double Length { get; }
+
+    IVector3 Normalize();
+
+    double Dot(IVector3 other);
+
+    IVector3 Cross(IVector3 other);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Primitives/Line3.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Primitives/Line3.cs
@@ -1,0 +1,12 @@
+namespace AssemblyChain.Geometry.Abstractions.Primitives;
+
+/// <summary>
+/// Represents a line segment between two points.
+/// </summary>
+public readonly record struct Line3(Point3 Start, Point3 End)
+{
+    public double Length => System.Math.Sqrt(
+        System.Math.Pow(End.X - Start.X, 2) +
+        System.Math.Pow(End.Y - Start.Y, 2) +
+        System.Math.Pow(End.Z - Start.Z, 2));
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Primitives/Plane3.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Primitives/Plane3.cs
@@ -1,0 +1,21 @@
+using AssemblyChain.Geometry.Abstractions.Interfaces;
+
+namespace AssemblyChain.Geometry.Abstractions.Primitives;
+
+/// <summary>
+/// Represents a geometric plane defined by an origin and normal.
+/// </summary>
+public readonly record struct Plane3(Point3 Origin, Vector3 Normal)
+{
+    public Plane3(Point3 origin, IVector3 normal)
+        : this(origin, new Vector3(normal.X, normal.Y, normal.Z))
+    {
+    }
+
+    public double DistanceTo(Point3 point)
+    {
+        var normalized = Normal.Normalize();
+        var vector = new Vector3(point.X - Origin.X, point.Y - Origin.Y, point.Z - Origin.Z);
+        return vector.Dot(normalized);
+    }
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Primitives/Point3.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Primitives/Point3.cs
@@ -1,0 +1,9 @@
+namespace AssemblyChain.Geometry.Abstractions.Primitives;
+
+/// <summary>
+/// Represents a 3D point in space.
+/// </summary>
+public readonly record struct Point3(double X, double Y, double Z)
+{
+    public static Point3 Origin => new(0d, 0d, 0d);
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Primitives/Pose6D.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Primitives/Pose6D.cs
@@ -1,0 +1,41 @@
+using System;
+using AssemblyChain.Geometry.Abstractions.Interfaces;
+
+namespace AssemblyChain.Geometry.Abstractions.Primitives;
+
+/// <summary>
+/// Represents a 6 degree of freedom pose using XYZ translation and ZYX Euler angles.
+/// </summary>
+public readonly record struct Pose6D(Point3 Position, Vector3 EulerAngles)
+{
+    /// <summary>
+    /// Creates a transform matrix from the pose.
+    /// </summary>
+    public Transform ToTransform()
+    {
+        var (rx, ry, rz) = (EulerAngles.X, EulerAngles.Y, EulerAngles.Z);
+        var (sx, cx) = (Math.Sin(rx), Math.Cos(rx));
+        var (sy, cy) = (Math.Sin(ry), Math.Cos(ry));
+        var (sz, cz) = (Math.Sin(rz), Math.Cos(rz));
+
+        var m00 = cz * cy;
+        var m01 = cz * sy * sx - sz * cx;
+        var m02 = cz * sy * cx + sz * sx;
+
+        var m10 = sz * cy;
+        var m11 = sz * sy * sx + cz * cx;
+        var m12 = sz * sy * cx - cz * sx;
+
+        var m20 = -sy;
+        var m21 = cy * sx;
+        var m22 = cy * cx;
+
+        return new Transform(new double[,]
+        {
+            { m00, m01, m02, Position.X },
+            { m10, m11, m12, Position.Y },
+            { m20, m21, m22, Position.Z },
+            { 0d,  0d,  0d,  1d }
+        });
+    }
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Primitives/ToleranceProfile.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Primitives/ToleranceProfile.cs
@@ -1,0 +1,8 @@
+using AssemblyChain.Geometry.Abstractions.Interfaces;
+
+namespace AssemblyChain.Geometry.Abstractions.Primitives;
+
+/// <summary>
+/// Value type implementing <see cref="IToleranceProfile"/>.
+/// </summary>
+public readonly record struct ToleranceProfile(double Linear, double Angular) : IToleranceProfile;

--- a/src/AssemblyChain.Geometry.Abstractions/Primitives/Transform.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Primitives/Transform.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using AssemblyChain.Geometry.Abstractions.Interfaces;
+
+namespace AssemblyChain.Geometry.Abstractions.Primitives;
+
+/// <summary>
+/// Represents a 4x4 homogeneous transform matrix.
+/// </summary>
+public readonly struct Transform : IMatrix4
+{
+    private readonly double[,] matrix;
+
+    public Transform(double[,] matrix)
+    {
+        if (matrix.GetLength(0) != 4 || matrix.GetLength(1) != 4)
+        {
+            throw new ArgumentException("Transform matrix must be 4x4.", nameof(matrix));
+        }
+
+        this.matrix = (double[,])matrix.Clone();
+    }
+
+    public double this[int row, int column] => matrix[row, column];
+
+    public IEnumerable<double> GetRow(int rowIndex)
+    {
+        for (var column = 0; column < 4; column++)
+        {
+            yield return matrix[rowIndex, column];
+        }
+    }
+
+    public IEnumerable<double> GetColumn(int columnIndex)
+    {
+        for (var row = 0; row < 4; row++)
+        {
+            yield return matrix[row, columnIndex];
+        }
+    }
+
+    public double Determinant
+    {
+        get
+        {
+            // Basic Laplace expansion for clarity over performance.
+            double det = 0d;
+            for (var column = 0; column < 4; column++)
+            {
+                det += matrix[0, column] * Cofactor(0, column);
+            }
+
+            return det;
+        }
+    }
+
+    public IMatrix4 Multiply(IMatrix4 other)
+    {
+        var result = new double[4, 4];
+        for (var row = 0; row < 4; row++)
+        {
+            for (var column = 0; column < 4; column++)
+            {
+                double sum = 0d;
+                for (var k = 0; k < 4; k++)
+                {
+                    sum += matrix[row, k] * other[k, column];
+                }
+
+                result[row, column] = sum;
+            }
+        }
+
+        return new Transform(result);
+    }
+
+    private double Cofactor(int row, int column)
+    {
+        var minor = Minor(row, column);
+        var sign = ((row + column) % 2) == 0 ? 1d : -1d;
+        return sign * Determinant3x3(minor);
+    }
+
+    private static double[,] Minor(int row, int column, double[,] source)
+    {
+        var minor = new double[3, 3];
+        var mi = 0;
+        for (var i = 0; i < 4; i++)
+        {
+            if (i == row)
+            {
+                continue;
+            }
+
+            var mj = 0;
+            for (var j = 0; j < 4; j++)
+            {
+                if (j == column)
+                {
+                    continue;
+                }
+
+                minor[mi, mj] = source[i, j];
+                mj++;
+            }
+
+            mi++;
+        }
+
+        return minor;
+    }
+
+    private double[,] Minor(int row, int column) => Minor(row, column, matrix);
+
+    private static double Determinant3x3(double[,] m)
+    {
+        return m[0, 0] * (m[1, 1] * m[2, 2] - m[1, 2] * m[2, 1])
+             - m[0, 1] * (m[1, 0] * m[2, 2] - m[1, 2] * m[2, 0])
+             + m[0, 2] * (m[1, 0] * m[2, 1] - m[1, 1] * m[2, 0]);
+    }
+}

--- a/src/AssemblyChain.Geometry.Abstractions/Primitives/Vector3.cs
+++ b/src/AssemblyChain.Geometry.Abstractions/Primitives/Vector3.cs
@@ -1,0 +1,24 @@
+using AssemblyChain.Geometry.Abstractions.Interfaces;
+
+namespace AssemblyChain.Geometry.Abstractions.Primitives;
+
+/// <summary>
+/// Lightweight implementation of <see cref="IVector3"/>.
+/// </summary>
+public readonly record struct Vector3(double X, double Y, double Z) : IVector3
+{
+    public double Length => System.Math.Sqrt(X * X + Y * Y + Z * Z);
+
+    public IVector3 Normalize()
+    {
+        var length = Length;
+        return length == 0d ? new Vector3(0d, 0d, 0d) : new Vector3(X / length, Y / length, Z / length);
+    }
+
+    public double Dot(IVector3 other) => X * other.X + Y * other.Y + Z * other.Z;
+
+    public IVector3 Cross(IVector3 other) => new Vector3(
+        Y * other.Z - Z * other.Y,
+        Z * other.X - X * other.Z,
+        X * other.Y - Y * other.X);
+}

--- a/src/AssemblyChain.Geometry/AssemblyChain.Geometry.csproj
+++ b/src/AssemblyChain.Geometry/AssemblyChain.Geometry.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\AssemblyChain.Core\AssemblyChain.Core.csproj" />
+    <ProjectReference Include="..\AssemblyChain.Geometry.Abstractions\AssemblyChain.Geometry.Abstractions.csproj" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Include="RhinoCommon" Version="$(RhinoCommonVersion)" ExcludeAssets="runtime" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- add a new AssemblyChain.Geometry.Abstractions project to host geometry contracts and value types
- define interfaces for primitives, mesh representations, and contact pipelines alongside supporting structs
- reference the abstractions project from the geometry implementation and register it in the solution

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6def0f15483238192dcfd66c60db8