### PR TITLE
Add workflow integration test and helper factories

### DIFF
--- a/src/AssemblyChain/Geometry/Contact/ContactModelFactory.cs
+++ b/src/AssemblyChain/Geometry/Contact/ContactModelFactory.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using AssemblyChain.IO.Contracts;
+using Rhino.Geometry;
+
+namespace AssemblyChain.Geometry.Contact
+{
+    /// <summary>
+    /// Factory helpers for creating <see cref="ContactModel"/> instances from raw contact data.
+    /// </summary>
+    public static class ContactModelFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="ContactModel"/> from an enumerable collection of contact records.
+        /// </summary>
+        /// <param name="contacts">The contact records to materialize.</param>
+        /// <param name="hashHint">Optional hash override when determinism must align with external caches.</param>
+        /// <returns>A read-only <see cref="ContactModel"/> instance.</returns>
+        public static ContactModel FromContacts(IEnumerable<ContactData> contacts, string? hashHint = null)
+        {
+            if (contacts == null)
+            {
+                throw new ArgumentNullException(nameof(contacts));
+            }
+
+            var sanitized = contacts
+                .Where(contact => contact != null)
+                .ToList();
+
+            var hash = string.IsNullOrWhiteSpace(hashHint)
+                ? ComputeHash(sanitized)
+                : hashHint!;
+
+            return new ContactModel(sanitized, hash);
+        }
+
+        private static string ComputeHash(IReadOnlyList<ContactData> contacts)
+        {
+            var builder = new StringBuilder();
+            builder.Append("CONTACT|");
+
+            foreach (var contact in contacts
+                .OrderBy(c => c.PartAId)
+                .ThenBy(c => c.PartBId)
+                .ThenBy(c => c.Type))
+            {
+                var plane = contact.Plane ?? new ContactPlane(Plane.WorldXY, Vector3d.ZAxis, Point3d.Origin);
+
+                builder.Append(contact.PartAId)
+                    .Append(':')
+                    .Append(contact.PartBId)
+                    .Append(':')
+                    .Append((int)contact.Type)
+                    .Append(':')
+                    .Append(contact.Zone?.Area.ToString("F6") ?? "0")
+                    .Append(':')
+                    .Append(contact.Zone?.Length.ToString("F6") ?? "0")
+                    .Append(':')
+                    .Append(contact.Zone?.Volume.ToString("F6") ?? "0")
+                    .Append(':')
+                    .Append(plane.Normal.X.ToString("F6"))
+                    .Append(':')
+                    .Append(plane.Normal.Y.ToString("F6"))
+                    .Append(':')
+                    .Append(plane.Normal.Z.ToString("F6"))
+                    .Append(':')
+                    .Append(plane.Center.X.ToString("F6"))
+                    .Append(':')
+                    .Append(plane.Center.Y.ToString("F6"))
+                    .Append(':')
+                    .Append(plane.Center.Z.ToString("F6"))
+                    .Append(':')
+                    .Append(contact.FrictionCoefficient.ToString("F6"))
+                    .Append('|');
+            }
+
+            using var sha256 = SHA256.Create();
+            var bytes = Encoding.UTF8.GetBytes(builder.ToString());
+            var hashBytes = sha256.ComputeHash(bytes);
+            return BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLowerInvariant();
+        }
+    }
+}

--- a/src/AssemblyChain/Planning/Model/SolverModelFactory.cs
+++ b/src/AssemblyChain/Planning/Model/SolverModelFactory.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AssemblyChain.Planning.Model
+{
+    /// <summary>
+    /// Factory utilities for constructing <see cref="DgSolverModel"/> instances in tests and tooling.
+    /// </summary>
+    public static class SolverModelFactory
+    {
+        /// <summary>
+        /// Creates a <see cref="DgSolverModel"/> from the provided components.
+        /// </summary>
+        /// <param name="steps">Ordered sequence steps.</param>
+        /// <param name="vectors">Motion vectors associated with each step.</param>
+        /// <param name="groups">Optional batching groups.</param>
+        /// <param name="isFeasible">Whether the solution is feasible.</param>
+        /// <param name="isOptimal">Whether the solution is optimal.</param>
+        /// <param name="log">Diagnostic log output.</param>
+        /// <param name="solveTimeSeconds">Reported solve time.</param>
+        /// <param name="solverType">Solver identifier.</param>
+        /// <param name="metadata">Additional metadata.</param>
+        /// <param name="isAssemblySequence">Indicates if the model represents an assembly sequence.</param>
+        /// <returns>A populated <see cref="DgSolverModel"/>.</returns>
+        public static DgSolverModel Create(
+            IEnumerable<Step> steps,
+            IEnumerable<Rhino.Geometry.Vector3d> vectors,
+            IEnumerable<IReadOnlyList<int>>? groups = null,
+            bool isFeasible = true,
+            bool isOptimal = true,
+            string? log = null,
+            double solveTimeSeconds = 0.0,
+            string? solverType = null,
+            IReadOnlyDictionary<string, object>? metadata = null,
+            bool isAssemblySequence = false)
+        {
+            if (steps == null)
+            {
+                throw new ArgumentNullException(nameof(steps));
+            }
+
+            if (vectors == null)
+            {
+                throw new ArgumentNullException(nameof(vectors));
+            }
+
+            var stepList = steps.ToList();
+            var vectorList = vectors.ToList();
+
+            if (stepList.Count != vectorList.Count)
+            {
+                throw new ArgumentException("Steps and vectors must have the same number of elements.", nameof(vectors));
+            }
+
+            var groupList = groups != null
+                ? groups.Select(g => (IReadOnlyList<int>)g.ToList()).ToList()
+                : new List<IReadOnlyList<int>>();
+
+            var metadataDictionary = metadata != null
+                ? new Dictionary<string, object>(metadata)
+                : new Dictionary<string, object>();
+
+            return new DgSolverModel(
+                stepList,
+                vectorList,
+                groupList,
+                isFeasible,
+                isOptimal,
+                log ?? string.Empty,
+                solveTimeSeconds,
+                solverType ?? "Unknown",
+                metadataDictionary,
+                isAssemblySequence);
+        }
+    }
+}

--- a/tests/AssemblyChain.Core.Tests/Workflow/WorkflowIntegrationTests.cs
+++ b/tests/AssemblyChain.Core.Tests/Workflow/WorkflowIntegrationTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AssemblyChain.Analysis.Learning;
+using AssemblyChain.Core.Domain.Entities;
+using AssemblyChain.Core.Domain.ValueObjects;
+using AssemblyChain.Geometry.Contact;
+using AssemblyChain.IO.Contracts;
+using AssemblyChain.IO.Data;
+using AssemblyChain.Planning.Facade;
+using AssemblyChain.Planning.Model;
+using AssemblyChain.Planning.Solver;
+using Rhino.Geometry;
+using Xunit;
+
+namespace AssemblyChain.Core.Tests.Workflow
+{
+    public class WorkflowIntegrationTests
+    {
+        [Fact]
+        public void Facade_Composes_Modules_Into_Executable_Workflow()
+        {
+            // Arrange
+            var assembly = BuildAssembly();
+            var assemblyModel = AssemblyModelFactory.Create(assembly);
+
+            var zone = new ContactZone(new PlaneSurface(Plane.WorldXY, new Interval(0, 1), new Interval(0, 1)), area: 1.0);
+            var plane = new ContactPlane(Plane.WorldXY, Vector3d.ZAxis, Point3d.Origin);
+            var contacts = ContactModelFactory.FromContacts(new[]
+            {
+                new ContactData("P0000", "P0001", ContactType.Face, zone, plane, frictionCoefficient: 0.4)
+            });
+
+            var constraintModel = ConstraintModelFactory.CreateEmpty(assemblyModel);
+            var solverOptions = new SolverOptions(SolverType.CSP);
+
+            var fakeSolver = new FakeSolver();
+            var facade = new AssemblyChainFacade(
+                solverFactory: _ => fakeSolver,
+                inferenceService: new OnnxInferenceService());
+
+            var request = new AssemblyPlanRequest(
+                assemblyModel,
+                contacts,
+                constraintModel,
+                detection: null,
+                solver: solverOptions);
+
+            var tempRoot = Path.Combine(Path.GetTempPath(), $"ac_workflow_{Guid.NewGuid():N}");
+            var processPath = Path.Combine(tempRoot, "process", "workflow.json");
+            var datasetDirectory = Path.Combine(tempRoot, "dataset");
+
+            try
+            {
+                // Act
+                var planResult = facade.RunPlan(request);
+                var initialSolver = planResult.SolverResult;
+
+                var directResult = facade.BuildAndSolve(assemblyModel, solverOptions, contacts, constraintModel);
+
+                var processOptions = new ProcessExportOptions
+                {
+                    OutputPath = processPath,
+                    IncludeMetadata = true,
+                    Author = "workflow-test"
+                };
+                var processSchema = facade.ExportProcess(initialSolver, processOptions);
+
+                var datasetOptions = new DatasetExportOptions
+                {
+                    OutputDirectory = datasetDirectory,
+                    IncludeGeometry = true,
+                    Tags = new[] { "integration" }
+                };
+                var datasetResult = facade.ExportDataset(assemblyModel, contacts, initialSolver, datasetOptions);
+
+                var inferenceRequest = new OnnxInferenceRequest(assemblyModel, new Dictionary<string, double>
+                {
+                    ["graspability"] = 0.85
+                });
+                var inferenceResult = facade.RunInference(inferenceRequest);
+
+                // Assert
+                Assert.Equal(2, fakeSolver.InvocationCount);
+                Assert.Same(contacts, planResult.Contacts);
+                Assert.Equal(assemblyModel.PartCount, initialSolver.StepCount);
+                Assert.Equal(initialSolver.StepCount, directResult.StepCount);
+                Assert.Equal(initialSolver.StepCount, processSchema.Steps.Count);
+                Assert.NotNull(processSchema.Metadata);
+                Assert.True(File.Exists(processPath));
+                Assert.Equal(1, datasetResult.RecordCount);
+                Assert.True(Directory.Exists(datasetResult.Directory));
+                var datasetFile = Path.Combine(datasetResult.Directory, $"{assemblyModel.Name.Replace(' ', '_')}_dataset.json");
+                Assert.True(File.Exists(datasetFile));
+                Assert.True(inferenceResult.Scores.ContainsKey("stability"));
+                Assert.True(inferenceResult.Scores.ContainsKey("graspability"));
+            }
+            finally
+            {
+                if (Directory.Exists(tempRoot))
+                {
+                    Directory.Delete(tempRoot, recursive: true);
+                }
+            }
+        }
+
+        private static Assembly BuildAssembly()
+        {
+            var assembly = new Assembly(id: 1, name: "WorkflowAssembly");
+            assembly.AddPart(CreatePart(0, "PartA", offsetX: 0.0));
+            assembly.AddPart(CreatePart(1, "PartB", offsetX: 1.5));
+            return assembly;
+        }
+
+        private static Part CreatePart(int id, string name, double offsetX)
+        {
+            var mesh = new Mesh();
+            mesh.Vertices.Add(offsetX, 0, 0);
+            mesh.Vertices.Add(offsetX + 1, 0, 0);
+            mesh.Vertices.Add(offsetX, 1, 0);
+            mesh.Vertices.Add(offsetX, 0, 1);
+            mesh.Faces.AddFace(0, 1, 2);
+            mesh.Faces.AddFace(0, 2, 3);
+            mesh.Normals.ComputeNormals();
+            mesh.Compact();
+
+            var geometry = new PartGeometry(id, mesh);
+            return new Part(id, name, geometry);
+        }
+
+        private sealed class FakeSolver : ISolver
+        {
+            public int InvocationCount { get; private set; }
+
+            public DgSolverModel Solve(AssemblyModel assembly, ContactModel contacts, ConstraintModel constraints, SolverOptions options = default)
+            {
+                InvocationCount++;
+
+                var steps = new List<Step>();
+                var vectors = new List<Vector3d>();
+
+                for (int i = 0; i < assembly.PartCount; i++)
+                {
+                    var part = assembly.Parts[i];
+                    var direction = new Vector3d(0, 0, 1 + i);
+                    steps.Add(new Step(i, part, direction) { Insert = true, Batch = 0 });
+                    vectors.Add(direction);
+                }
+
+                var metadata = new Dictionary<string, object>
+                {
+                    ["solverType"] = options.SolverType.ToString(),
+                    ["invocation"] = InvocationCount
+                };
+
+                return SolverModelFactory.Create(
+                    steps,
+                    vectors,
+                    groups: new[] { (IReadOnlyList<int>)new List<int> { 0, 1 } },
+                    isFeasible: true,
+                    isOptimal: true,
+                    log: "fake-solver",
+                    solveTimeSeconds: 0.01 * InvocationCount,
+                    solverType: options.SolverType.ToString(),
+                    metadata: metadata);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a contact model factory to materialize read-only contact models from raw contact data
- expose a solver model factory helper for constructing DgSolverModel instances in tests and tooling
- add an end-to-end workflow integration test exercising planning, export, and inference paths

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6ee2bc43c8323a0900892a3481626